### PR TITLE
feat: make state_files optional with default state-bucket discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This gives Infracost the ability to improve our algorithm that maps cloud resour
 
 ## Usage instructions
 
-1. Use the module to create the cross account role in your AWS account
+1. Use the module to create the parser Lambda in your AWS account
 
 ```hcl
 provider "aws" {
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 module "infracost_state_parser" {
-  source = "github.com/infracost/infracost-state-parser-module?ref=v0.2.0"
+  source = "github.com/infracost/infracost-state-parser-module?ref=v0.4.0"
 
   providers = {
     aws = aws
@@ -25,49 +25,28 @@ module "infracost_state_parser" {
 
   organization_id = "your_organization_id"
 
-  # You can pass in path prefixes or full paths to state files
-  state_files = [
-    "s3://your_bucket/statefiles/*",
-    "s3://your_other_bucket/full/path/to/statefile.json"
-  ]
+  # Optional: explicit path prefixes or full paths to state files. If omitted,
+  # the parser finds S3 buckets whose names reference Terraform/IaC state
+  # (e.g. tfstate, terraform-state, prod-tf-state-us-east-1) and scans them
+  # for *.tfstate objects.
+  # state_files = [
+  #   "s3://your_bucket/statefiles/*",
+  #   "s3://your_other_bucket/full/path/to/statefile.json"
+  # ]
 
   # state_kms_key_arns = ["arn:aws:kms:us-west-2:123456789012:key/your-key-id"] # Optional KMS keys used to encrypt the state files.
   # schedule_period = "PT1H" # Optional ISO 8601 period between parser runs. Defaults to one hour.
   # log_level = "INFO" # Optional log level for the Lambda function. Valid values are `DEBUG`, `INFO` (default), `WARN`, or `ERROR`.
 }
-
-// the ARN of the Lambda function created by this module
-// give this ARN to Infracost to enable state parsing
-output "infracost_state_parser_lambda_role_arn" {
-  value = module.infracost_state_parser.iam_role_arn
-}
 ```
 
-2. Run `terraform init` and `terraform apply` to create the statefile parser
-
-3. Email the `infracost_state_parser_lambda_role_arn` outputs to Infracost:
-
-```text
-To: support@infracost.io
-Subject: Enable Statefile parser for Infracost Cloud
-
-Body:
-Hi, my name is Rafa and I'm the DevOps Lead at ACME Corporation.
-
-- Infracost Cloud org ID: $YOUR_INFRACOST_ORGANIZATION_ID
-- Our statefile parser Lambda ARNs are:
-<terraform output infracost_state_parser_lambda_role_arn>
-
-Regards,
-Rafa
-```
+2. Run `terraform init` and `terraform apply` to create the statefile parser. No further setup is needed - the parser sends its reports to Infracost automatically.
 
 ## How will Infracost use the above access?
 
 1. This sets up a Lambda function that runs periodically using a CloudWatch Event Rule
-2. This Lambda function is given access to an S3 bucket in Infracost's account.
-2. It scans your S3 bucket for Terraform statefiles and extracts the attributes listed below.
-3. It then sends a subset of the below attributes to the S3 bucket in Infracost's account:
+2. It scans your configured state files (or discovered state buckets) and extracts the attributes listed below.
+3. It then sends a subset of the below attributes to an S3 bucket in Infracost's account:
 
 For all resources:
  * `id`
@@ -77,26 +56,15 @@ For all resources:
 
 For `aws_instance`:
  * `instance_type`
+ * `ami`
  * `availability_zone`
- * `launch_template.id`
- * `launch_template.name`
- * `launch_template.version`
- * `root_block_device.volume_id`
- * `root_block_device.volume_type`
- * `root_block_device.volume_size`
- * `root_block_device.iops`
- * `root_block_device.throughput`
- * `ebs_block_device.device_name`
- * `ebs_block_device.volume_id`
- * `ebs_block_device.volume_type`
- * `ebs_block_device.volume_size`
- * `ebs_block_device.iops`
- * `ebs_block_device.throughput`
 
 For `aws_db_instance`:
+ * `identifier`
  * `instance_class`
  * `engine`
  * `engine_version`
+ * `endpoint`
  * `multi_az`
  * `allocated_storage`
  * `storage_type`
@@ -106,48 +74,46 @@ For `aws_rds_cluster`:
  * `database_name`
  * `engine`
  * `engine_version`
- * `instance_class`
+ * `db_cluster_instance_class`
+ * `endpoint`
 
 For `aws_rds_cluster_instance`:
  * `cluster_identifier`
- * `instance_identifier`
+ * `identifier`
  * `instance_class`
+ * `engine`
+ * `engine_version`
+ * `endpoint`
+
+For `aws_s3_bucket`:
+ * `bucket`
+ * `bucket_domain_name`
+ * `bucket_region`
 
 For `aws_autoscaling_group`:
  * `name`
  * `min_size`
  * `max_size`
  * `desired_capacity`
+ * `launch_configuration`
+ * `launch_template.id`
+ * `launch_template.name`
+ * `launch_template.version`
+ * `launch_template.instance_type` (resolved from the launch template)
 
 For `aws_launch_template`:
  * `name`
- * `version`
- * `instance_type`
  * `image_id`
- * `placement.availability_zone`
- * `block_device_mappings.device_name`
- * `block_device_mappings.ebs.volume_type`
- * `block_device_mappings.ebs.volume_size`
- * `block_device_mappings.ebs.iops`
- * `block_device_mappings.ebs.throughput`
+ * `instance_type`
+ * `default_version`
+ * `latest_version`
 
 For `aws_launch_configuration`:
  * `name`
  * `image_id`
  * `instance_type`
- * `root_block_device.volume_type`
- * `root_block_device.volume_size`
- * `root_block_device.iops`
- * `root_block_device.throughput`
- * `ebs_block_device.device_name`
- * `ebs_block_device.volume_id`
- * `ebs_block_device.volume_type`
- * `ebs_block_device.volume_size`
- * `ebs_block_device.iops`
- * `ebs_block_device.throughput`
 
 For `aws_eks_cluster`:
- * `cluster_id`
  * `name`
  * `version`
 
@@ -155,7 +121,6 @@ For `aws_eks_node_group`:
  * `cluster_name`
  * `node_group_name`
  * `ami_type`
- * `disk_size`
  * `instance_types`
  * `launch_template`
  * `version`
@@ -168,20 +133,12 @@ For `aws_ecs_service`:
  * `name`
  * `cluster`
  * `launch_type`
-
-For `aws_ecs_task_definition`:
- * `family`
- * `cpu`
- * `memory`
- * `required_compatibilities`
- * `runtime_platform.operating_system_family`
- * `runtime_platform.cpu_architecture`
+ * `platform_version`
 
 For `aws_lambda_function`:
  * `function_name`
  * `architectures`
- * `ephemeral_storage`
- * `memory_size`
+ * `runtime`
 
 ## Updates
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ module "infracost_state_parser" {
   organization_id = "your_organization_id"
 
   # Optional: explicit path prefixes or full paths to state files. If omitted,
-  # the parser finds S3 buckets whose names reference Terraform/IaC state
-  # (e.g. tfstate, terraform-state, prod-tf-state-us-east-1) and scans them
-  # for *.tfstate objects.
+  # the parser finds S3 buckets whose names reference Terraform, Terragrunt or
+  # IaC state (e.g. tfstate, terraform-state, acme-prod-statefiles,
+  # terragrunt-123456789012-us-east-1) and scans them for *.tfstate objects.
   # state_files = [
   #   "s3://your_bucket/statefiles/*",
   #   "s3://your_other_bucket/full/path/to/statefile.json"

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 This gives Infracost the ability to improve our algorithm that maps cloud resources to IaC code. The parser is a Lambda function that is deployed in your AWS accounts that contain your Terraform Statefiles so it can extract certain non-sensitive/non-secret attributes to send to Infracost periodically.
 
 ## Prerequisites
-- You have an AWS account
-- You need your Infracost Cloud organization ID - find this in the Org Settings of [Infracost Cloud](https://dashboard.infracost.io)
+- You have an AWS account.
+- You need your Infracost Cloud organization ID - find this in the Org Settings of [Infracost Cloud](https://dashboard.infracost.io).
 - You store your Terraform state files in S3. Please email support@infracost.io if you use other state stores.
 
 ## Usage instructions
 
-1. Use the module to create the parser Lambda in your AWS account
+1. Use the module to create the parser Lambda in your AWS account:
 
 ```hcl
 provider "aws" {
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 module "infracost_state_parser" {
-  source = "github.com/infracost/infracost-state-parser-module?ref=v0.4.0"
+  source = "github.com/infracost/infracost-state-parser-module?ref=v0.2.1"
 
   providers = {
     aws = aws
@@ -28,7 +28,8 @@ module "infracost_state_parser" {
   # Optional: explicit path prefixes or full paths to state files. If omitted,
   # the parser finds S3 buckets whose names reference Terraform, Terragrunt or
   # IaC state (e.g. tfstate, terraform-state, acme-prod-statefiles,
-  # terragrunt-123456789012-us-east-1) and scans them for *.tfstate objects.
+  # terragrunt-123456789012-us-east-1) and scans them for *.tfstate and
+  # *.json objects.
   # state_files = [
   #   "s3://your_bucket/statefiles/*",
   #   "s3://your_other_bucket/full/path/to/statefile.json"
@@ -40,11 +41,26 @@ module "infracost_state_parser" {
 }
 ```
 
-2. Run `terraform init` and `terraform apply` to create the statefile parser. No further setup is needed - the parser sends its reports to Infracost automatically.
+2. Run `terraform init` and `terraform apply` to create the statefile parser.
+
+3. Email support@infracost.io so we can enable state parsing for your organization:
+
+```text
+To: support@infracost.io
+Subject: Enable Statefile parser for Infracost Cloud
+
+Body:
+Hi, my name is Rafa and I'm the DevOps Lead at ACME Corporation.
+
+- Infracost Cloud org ID: $YOUR_INFRACOST_ORGANIZATION_ID
+
+Regards,
+Rafa
+```
 
 ## How will Infracost use the above access?
 
-1. This sets up a Lambda function that runs periodically using a CloudWatch Event Rule
+1. This sets up a Lambda function that runs periodically using a CloudWatch Event Rule.
 2. It scans your configured state files (or discovered state buckets) and extracts the attributes listed below.
 3. It then sends a subset of the below attributes to an S3 bucket in Infracost's account:
 

--- a/iam.tf
+++ b/iam.tf
@@ -61,22 +61,45 @@ data "aws_iam_policy_document" "state_file_access" {
     }
   }
 
-  statement {
-    sid     = "ReadConfiguredStateObjects"
-    effect  = "Allow"
-    actions = ["s3:GetObject"]
-    resources = [
-      for source in local.parsed_state_files : "arn:aws:s3:::${source.bucket}/${source.key_pattern}"
-    ]
+  dynamic "statement" {
+    for_each = length(local.parsed_state_files) > 0 ? [1] : []
+    content {
+      sid     = "ReadConfiguredStateObjects"
+      effect  = "Allow"
+      actions = ["s3:GetObject"]
+      resources = [
+        for source in local.parsed_state_files : "arn:aws:s3:::${source.bucket}/${source.key_pattern}"
+      ]
+    }
   }
 
   dynamic "statement" {
-    for_each = length(local.wildcard_bucket_sources) > 0 ? [1] : []
+    for_each = length(local.wildcard_bucket_sources) > 0 || local.default_discovery ? [1] : []
     content {
       sid       = "DiscoverMatchingBuckets"
       effect    = "Allow"
       actions   = ["s3:ListAllMyBuckets"]
       resources = ["*"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = local.default_discovery ? [1] : []
+    content {
+      sid       = "DefaultDiscoveryInspectBuckets"
+      effect    = "Allow"
+      actions   = ["s3:GetBucketLocation", "s3:ListBucket"]
+      resources = local.default_discovery_bucket_arns
+    }
+  }
+
+  dynamic "statement" {
+    for_each = local.default_discovery ? [1] : []
+    content {
+      sid       = "DefaultDiscoveryReadStateObjects"
+      effect    = "Allow"
+      actions   = ["s3:GetObject"]
+      resources = [for arn in local.default_discovery_bucket_arns : "${arn}/*.tfstate"]
     }
   }
 

--- a/iam.tf
+++ b/iam.tf
@@ -96,10 +96,12 @@ data "aws_iam_policy_document" "state_file_access" {
   dynamic "statement" {
     for_each = local.default_discovery ? [1] : []
     content {
-      sid       = "DefaultDiscoveryReadStateObjects"
-      effect    = "Allow"
-      actions   = ["s3:GetObject"]
-      resources = [for arn in local.default_discovery_bucket_arns : "${arn}/*.tfstate"]
+      sid     = "DefaultDiscoveryReadStateObjects"
+      effect  = "Allow"
+      actions = ["s3:GetObject"]
+      resources = flatten([
+        for arn in local.default_discovery_bucket_arns : ["${arn}/*.tfstate", "${arn}/*.json"]
+      ])
     }
   }
 

--- a/lambda.tf
+++ b/lambda.tf
@@ -17,6 +17,7 @@ resource "aws_lambda_function" "state_file_parser" {
     variables = {
       ORGANIZATION_ID               = var.organization_id
       STATE_FILE_PATTERNS_JSON      = jsonencode(var.state_files)
+      DEFAULT_BUCKET_DISCOVERY      = local.default_discovery ? "true" : "false"
       INFRACOST_STATE_BUCKET        = var.state_bucket
       INFRACOST_STATE_BUCKET_REGION = "us-east-2"
       LOG_LEVEL                     = lower(var.log_level)

--- a/locals.tf
+++ b/locals.tf
@@ -17,6 +17,19 @@ locals {
   wildcard_bucket_sources = [for source in local.parsed_state_files : source if source.bucket_has_wildcard]
   exact_buckets           = toset([for source in local.exact_bucket_sources : source.bucket])
 
+  default_discovery = length(var.state_files) == 0
+  # Coarse IAM bound for default discovery: bucket names combining a
+  # Terraform/IaC token and "state" in either order. The parser applies the
+  # stricter name rule; IAM only needs to contain it.
+  default_discovery_bucket_arns = [
+    "arn:aws:s3:::*terraform*state*",
+    "arn:aws:s3:::*state*terraform*",
+    "arn:aws:s3:::*tf*state*",
+    "arn:aws:s3:::*state*tf*",
+    "arn:aws:s3:::*iac*state*",
+    "arn:aws:s3:::*state*iac*",
+  ]
+
   period_days    = try(tonumber(regex("^P([1-9][0-9]*)D$", var.schedule_period)[0]), 0)
   period_hours   = try(tonumber(regex("^PT([1-9][0-9]*)H$", var.schedule_period)[0]), 0)
   period_minutes = try(tonumber(regex("^PT([1-9][0-9]*)M$", var.schedule_period)[0]), 0)
@@ -29,7 +42,7 @@ locals {
   function_name  = "infracost-state-file-parser"
   image_uri      = "237144093413.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/infracost/state-parser"
   image_arn      = "arn:aws:ecr:${data.aws_region.current.region}:237144093413:repository/infracost/state-parser"
-  parser_version = "0.2.0"
+  parser_version = "0.4.0"
   image_ref      = "${local.image_uri}:${local.parser_version}"
 
   supported_image_regions = toset([

--- a/locals.tf
+++ b/locals.tf
@@ -39,7 +39,7 @@ locals {
   function_name  = "infracost-state-file-parser"
   image_uri      = "237144093413.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/infracost/state-parser"
   image_arn      = "arn:aws:ecr:${data.aws_region.current.region}:237144093413:repository/infracost/state-parser"
-  parser_version = "0.4.0"
+  parser_version = "0.2.1"
   image_ref      = "${local.image_uri}:${local.parser_version}"
 
   supported_image_regions = toset([

--- a/locals.tf
+++ b/locals.tf
@@ -18,16 +18,13 @@ locals {
   exact_buckets           = toset([for source in local.exact_bucket_sources : source.bucket])
 
   default_discovery = length(var.state_files) == 0
-  # Coarse IAM bound for default discovery: bucket names combining a
-  # Terraform/IaC token and "state" in either order. The parser applies the
-  # stricter name rule; IAM only needs to contain it.
+  # Coarse IAM bound for default discovery: every bucket name the parser's
+  # discovery rule can match contains "terraform", "terragrunt", or "state".
+  # The parser applies the stricter name rule; IAM only needs to contain it.
   default_discovery_bucket_arns = [
-    "arn:aws:s3:::*terraform*state*",
-    "arn:aws:s3:::*state*terraform*",
-    "arn:aws:s3:::*tf*state*",
-    "arn:aws:s3:::*state*tf*",
-    "arn:aws:s3:::*iac*state*",
-    "arn:aws:s3:::*state*iac*",
+    "arn:aws:s3:::*terraform*",
+    "arn:aws:s3:::*terragrunt*",
+    "arn:aws:s3:::*state*",
   ]
 
   period_days    = try(tonumber(regex("^P([1-9][0-9]*)D$", var.schedule_period)[0]), 0)

--- a/tests/module.tftest.hcl
+++ b/tests/module.tftest.hcl
@@ -43,7 +43,7 @@ run "minimal_default_contract" {
 
   assert {
     condition = (
-      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.2.0" &&
+      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.4.0" &&
       !contains(keys(aws_lambda_function.state_file_parser.environment[0].variables), "PARSER_AUTO_UPDATE") &&
       !strcontains(data.aws_iam_policy_document.state_file_access.json, "lambda:UpdateFunctionCode")
     )
@@ -91,6 +91,51 @@ run "minimal_default_contract" {
       try(statement.Resource == "arn:aws:logs:*:*:*", false)
     ]) == 1
     error_message = "The Lambda role must retain permissions to create its CloudWatch log group and streams and publish log events."
+  }
+}
+
+run "explicit_state_files_disable_default_discovery" {
+  command = plan
+
+  assert {
+    condition     = aws_lambda_function.state_file_parser.environment[0].variables.DEFAULT_BUCKET_DISCOVERY == "false"
+    error_message = "Configured state files must switch off default bucket discovery."
+  }
+
+  assert {
+    condition     = !strcontains(data.aws_iam_policy_document.state_file_access.json, "DefaultDiscovery")
+    error_message = "Configured state files must not receive default-discovery permissions."
+  }
+}
+
+run "omitted_state_files_enable_default_discovery" {
+  command = plan
+
+  variables { state_files = [] }
+
+  assert {
+    condition     = aws_lambda_function.state_file_parser.environment[0].variables.DEFAULT_BUCKET_DISCOVERY == "true"
+    error_message = "Omitted state files must enable default bucket discovery."
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.state_file_access.json, "s3:ListAllMyBuckets")
+    error_message = "Default discovery requires bucket listing."
+  }
+
+  assert {
+    condition = length([
+      for statement in jsondecode(data.aws_iam_policy_document.state_file_access.json).Statement : statement
+      if try(statement.Sid == "DefaultDiscoveryReadStateObjects", false) &&
+      try(statement.Action == "s3:GetObject", false) &&
+      alltrue([for resource in try(tolist(statement.Resource), [statement.Resource]) : endswith(resource, "/*.tfstate")])
+    ]) == 1
+    error_message = "Default discovery reads must be bounded to *.tfstate objects in state-named buckets."
+  }
+
+  assert {
+    condition     = !strcontains(data.aws_iam_policy_document.state_file_access.json, "ReadConfiguredStateObjects")
+    error_message = "No configured-object permissions should exist without configured state files."
   }
 }
 

--- a/tests/module.tftest.hcl
+++ b/tests/module.tftest.hcl
@@ -43,7 +43,7 @@ run "minimal_default_contract" {
 
   assert {
     condition = (
-      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.4.0" &&
+      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.2.1" &&
       !contains(keys(aws_lambda_function.state_file_parser.environment[0].variables), "PARSER_AUTO_UPDATE") &&
       !strcontains(data.aws_iam_policy_document.state_file_access.json, "lambda:UpdateFunctionCode")
     )
@@ -128,9 +128,9 @@ run "omitted_state_files_enable_default_discovery" {
       for statement in jsondecode(data.aws_iam_policy_document.state_file_access.json).Statement : statement
       if try(statement.Sid == "DefaultDiscoveryReadStateObjects", false) &&
       try(statement.Action == "s3:GetObject", false) &&
-      alltrue([for resource in try(tolist(statement.Resource), [statement.Resource]) : endswith(resource, "/*.tfstate")])
+      alltrue([for resource in try(tolist(statement.Resource), [statement.Resource]) : endswith(resource, "/*.tfstate") || endswith(resource, "/*.json")])
     ]) == 1
-    error_message = "Default discovery reads must be bounded to *.tfstate objects in state-named buckets."
+    error_message = "Default discovery reads must be bounded to *.tfstate and *.json objects in state-named buckets."
   }
 
   assert {

--- a/variables.tf
+++ b/variables.tf
@@ -9,11 +9,12 @@ variable "organization_id" {
 }
 
 variable "state_files" {
-  description = "S3 object paths or glob patterns containing Terraform state"
+  description = "S3 object paths or glob patterns containing Terraform state. When empty, the parser discovers buckets whose names reference Terraform/IaC state and scans them for *.tfstate objects."
   type        = list(string)
+  default     = []
 
   validation {
-    condition = length(var.state_files) > 0 && alltrue([
+    condition = alltrue([
       for source in var.state_files : can(regex("^s3://[^/]+/.+$", source))
     ])
     error_message = "state_files must contain valid s3://bucket/key paths."

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,7 @@ variable "state_files" {
   description = "S3 object paths or glob patterns containing Terraform state. When empty, the parser discovers buckets whose names reference Terraform/IaC state and scans them for *.tfstate objects."
   type        = list(string)
   default     = []
+  nullable    = false
 
   validation {
     condition = alltrue([

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "organization_id" {
 }
 
 variable "state_files" {
-  description = "S3 object paths or glob patterns containing Terraform state. When empty, the parser discovers buckets whose names reference Terraform/IaC state and scans them for *.tfstate objects."
+  description = "S3 object paths or glob patterns containing Terraform state. When empty, the parser discovers buckets whose names reference Terraform/Terragrunt/IaC state and scans them for *.tfstate and *.json objects."
   type        = list(string)
   default     = []
   nullable    = false


### PR DESCRIPTION
`state_files` now defaults to `[]`. When omitted, the Lambda gets `DEFAULT_BUCKET_DISCOVERY=true` and IAM to list buckets and read `*.tfstate` and `*.json` objects from buckets whose names contain `terraform`, `terragrunt`, or `state` — the parser applies a stricter token-based name rule (infracost/state-parser#18); the IAM patterns only need to contain it. Explicit `state_files` behave exactly as before and grant no discovery permissions.

Also corrects the README:
- resource/attribute lists now match the parser's allowlist (adds `aws_s3_bucket`, drops `aws_ecs_task_definition`, fixes stale attributes)
- removes the emailed Lambda-ARN step — no longer needed, reports flow automatically

Merge order: needs state-parser v0.2.1 released first (this bumps the pinned image to 0.2.1), then tag this module v0.2.1 to match the README ref.

## Checklist

- [x] [Technical docs](https://github.com/infracost/technical-docs) updated (or not needed)
- [x] `/review` at commit [19ccdfe](https://github.com/infracost/infracost-state-parser-module/commit/19ccdfe462e2b5ff52e80ca07fdb136c3508a362) produced a risk score of 4/10. Additive, backward-compatible feature with passing tests; broadens deployed IAM with `s3:ListAllMyBuckets` and coarse wildcard grants (`*terraform*`, `*terragrunt*`, `*state*`) bounded to `*.tfstate` objects, which warrants conscious sign-off.