### PR TITLE
fix: require AWS provider 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 module "infracost_state_parser" {
-  source = "github.com/infracost/infracost-state-parser-module?ref=v0.2.1"
+  source = "github.com/infracost/infracost-state-parser-module?ref=v0.2.2"
 
   providers = {
     aws = aws

--- a/locals.tf
+++ b/locals.tf
@@ -39,7 +39,7 @@ locals {
   function_name  = "infracost-state-file-parser"
   image_uri      = "237144093413.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/infracost/state-parser"
   image_arn      = "arn:aws:ecr:${data.aws_region.current.region}:237144093413:repository/infracost/state-parser"
-  parser_version = "0.2.1"
+  parser_version = "0.2.2"
   image_ref      = "${local.image_uri}:${local.parser_version}"
 
   supported_image_regions = toset([

--- a/tests/module.tftest.hcl
+++ b/tests/module.tftest.hcl
@@ -43,7 +43,7 @@ run "minimal_default_contract" {
 
   assert {
     condition = (
-      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.2.1" &&
+      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.2.2" &&
       !contains(keys(aws_lambda_function.state_file_parser.environment[0].variables), "PARSER_AUTO_UPDATE") &&
       !strcontains(data.aws_iam_policy_document.state_file_access.json, "lambda:UpdateFunctionCode")
     )

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.42, < 7.0"
+      version = ">= 6.0, < 7.0"
     }
   }
 }


### PR DESCRIPTION
Requires AWS provider 6 and pairs module v0.2.2 with parser v0.2.2.