### PR TITLE
fix: support AWS providers 5 and 6

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -31,7 +31,7 @@ resource "aws_lambda_function" "state_file_parser" {
 
   lifecycle {
     precondition {
-      condition     = contains(local.supported_image_regions, data.aws_region.current.region)
+      condition     = contains(local.supported_image_regions, data.aws_region.current.id)
       error_message = "The Infracost state-parser image is not replicated to this AWS region. Deploy in one of: ${join(", ", sort(tolist(local.supported_image_regions)))}."
     }
   }

--- a/locals.tf
+++ b/locals.tf
@@ -37,8 +37,8 @@ locals {
   expected_interval_seconds = (local.period_days * 86400) + (local.period_hours * 3600) + (local.period_minutes * 60)
 
   function_name  = "infracost-state-file-parser"
-  image_uri      = "237144093413.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/infracost/state-parser"
-  image_arn      = "arn:aws:ecr:${data.aws_region.current.region}:237144093413:repository/infracost/state-parser"
+  image_uri      = "237144093413.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/infracost/state-parser"
+  image_arn      = "arn:aws:ecr:${data.aws_region.current.id}:237144093413:repository/infracost/state-parser"
   parser_version = "0.2.2"
   image_ref      = "${local.image_uri}:${local.parser_version}"
 

--- a/tests/module.tftest.hcl
+++ b/tests/module.tftest.hcl
@@ -10,7 +10,7 @@ provider "aws" {
 
 override_data {
   target = data.aws_region.current
-  values = { region = "us-east-2" }
+  values = { id = "us-east-2" }
 }
 
 override_data {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0, < 7.0"
+      version = ">= 5.42, < 7.0"
     }
   }
 }


### PR DESCRIPTION
Use the shared `aws_region.id` attribute and allow AWS provider versions from 5.42 through 6.x.

Validated with all 15 Terraform tests on AWS provider 5.100.0 and 6.56.0. Adversarial review also verified the v5.42 lower bound.
