### PR TITLE
feat: support customer-controlled parser deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 module "infracost_state_parser" {
-  source = "github.com/infracost/infracost-state-parser-module?ref=v0.2.2"
+  source = "github.com/infracost/infracost-state-parser-module?ref=v0.2.3"
 
   providers = {
     aws = aws
@@ -38,6 +38,21 @@ module "infracost_state_parser" {
   # state_kms_key_arns = ["arn:aws:kms:us-west-2:123456789012:key/your-key-id"] # Optional KMS keys used to encrypt the state files.
   # schedule_period = "PT1H" # Optional ISO 8601 period between parser runs. Defaults to one hour.
   # log_level = "INFO" # Optional log level for the Lambda function. Valid values are `DEBUG`, `INFO` (default), `WARN`, or `ERROR`.
+
+  # Optional destination overrides. The bucket can be owned by you or by
+  # another AWS account that permits this module's Lambda role to write.
+  # state_bucket        = "your-report-bucket"
+  # state_bucket_region = "us-west-2"
+  # state_bucket_prefix = "infracost-reports"
+
+  # Optional VPC configuration in which to run the Lambda.
+  # vpc_config = {
+  #   subnet_ids         = ["subnet-0123456789abcdef0"]
+  #   security_group_ids = ["sg-0123456789abcdef0"]
+  # }
+
+  # Optional customer-managed parser image. Tags and digests are supported.
+  # parser_image_uri = "123456789012.dkr.ecr.us-west-2.amazonaws.com/infracost-state-parser:v0.2.3"
 }
 ```
 
@@ -62,7 +77,7 @@ Rafa
 
 1. This sets up a Lambda function that runs periodically using a CloudWatch Event Rule.
 2. It scans your configured state files (or discovered state buckets) and extracts the attributes listed below.
-3. It then sends a subset of the below attributes to an S3 bucket in Infracost's account:
+3. It then sends a subset of the below attributes to the configured S3 destination bucket:
 
 For all resources:
  * `id`
@@ -155,6 +170,88 @@ For `aws_lambda_function`:
  * `function_name`
  * `architectures`
  * `runtime`
+
+## Report destination
+
+By default, reports are written to the Infracost-managed destination. You can
+instead set `state_bucket`, `state_bucket_region`, and optionally
+`state_bucket_prefix` to deliver reports to a bucket under your control.
+
+The Lambda role can write only this object in each deployment account:
+
+```text
+<prefix>/<organization_id>/aws_account_id=<account_id>/terraform-state-resources.json
+```
+
+When `state_bucket_prefix` is empty, the key starts with `organization_id`.
+The destination bucket policy is managed outside this module and must permit
+the role exposed by the `iam_role_arn` output to call `s3:PutObject` on that
+object.
+
+For deployments across accounts in one AWS Organization, a customer-managed
+bucket policy can authorize the dedicated parser role while retaining an exact
+account-specific object path. Replace the placeholders and omit
+`DESTINATION_PREFIX/` when no prefix is configured:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowOrganizationStateParserReports",
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": "s3:PutObject",
+    "Resource": "arn:aws:s3:::DESTINATION_BUCKET/DESTINATION_PREFIX/INFRACOST_ORGANIZATION_ID/aws_account_id=${aws:PrincipalAccount}/terraform-state-resources.json",
+    "Condition": {
+      "StringEquals": {
+        "aws:PrincipalOrgID": "o-EXAMPLEORGID"
+      },
+      "ArnLike": {
+        "aws:PrincipalArn": "arn:aws:iam::*:role/infracost-state-parser-role"
+      }
+    }
+  }]
+}
+```
+
+The AWS Organization ID in `aws:PrincipalOrgID` is distinct from the Infracost
+organization ID used in the report key.
+
+## VPC configuration
+
+Set `vpc_config` to attach the Lambda to existing subnets and security groups.
+The subnets and security groups must belong to the same VPC and AWS region.
+
+This module does not create or validate network routes, internet egress, VPC
+endpoints, endpoint policies, or security-group rules. The supplied network must
+provide connectivity to every S3 bucket used by the parser. VPC attachment and
+detachment can take several minutes while Lambda manages its network interfaces.
+
+The IAM principal running Terraform needs these permissions in addition to the
+permissions normally required to deploy the module:
+
+```text
+ec2:DescribeSecurityGroups
+ec2:DescribeSubnets
+ec2:DescribeVpcs
+ec2:GetSecurityGroupsForVpc
+```
+
+AWS documents the separate deployment and execution-role permission sets in
+[Giving Lambda functions access to resources in an Amazon VPC](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html#configuration-vpc-permissions).
+
+## Customer-managed parser image
+
+Set `parser_image_uri` to deploy an image from a private ECR repository under
+your control. The image must be in the Lambda function's AWS region, must contain
+a Lambda-compatible Linux ARM64 image, and must not be a multi-architecture
+image index. You are responsible for the ECR repository policy, including any
+cross-account access required by Lambda.
+
+Tags and digests are both accepted. When using a tag, publish a new tag whenever
+the image changes. Overwriting an existing tag does not change Terraform's
+`image_uri` and therefore does not cause Lambda to update its code. Digest
+pinning is available but not required.
 
 ## Updates
 

--- a/iam.tf
+++ b/iam.tf
@@ -17,28 +17,33 @@ data "aws_iam_policy_document" "state_file_access" {
     resources = ["arn:aws:logs:*:*:*"]
   }
 
-  statement {
-    effect = "Allow"
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:BatchGetImage"
-    ]
-    resources = [local.image_arn]
+  dynamic "statement" {
+    for_each = local.managed_image ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage"
+      ]
+      resources = [local.image_arn]
+    }
   }
 
-  statement {
-    effect    = "Allow"
-    actions   = ["ecr:GetAuthorizationToken"]
-    resources = ["*"]
+  dynamic "statement" {
+    for_each = local.managed_image ? [1] : []
+    content {
+      effect    = "Allow"
+      actions   = ["ecr:GetAuthorizationToken"]
+      resources = ["*"]
+    }
   }
 
   statement {
     sid       = "WriteSanitizedReports"
     effect    = "Allow"
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::${var.state_bucket}/${var.organization_id}/aws_account_id=${data.aws_caller_identity.current.account_id}/terraform-state-resources.json"]
+    resources = ["arn:aws:s3:::${var.state_bucket}/${local.state_report_key}"]
   }
 
   dynamic "statement" {
@@ -161,6 +166,29 @@ resource "aws_iam_role" "state_file_parser" {
 resource "aws_iam_role_policy_attachment" "state_file_access_policy_attachement" {
   role       = aws_iam_role.state_file_parser.name
   policy_arn = aws_iam_policy.state_file_access.arn
+}
+
+resource "aws_iam_role_policy" "vpc_access" {
+  count = var.vpc_config == null ? 0 : 1
+
+  name = "infracost-state-parser-vpc-access"
+  role = aws_iam_role.state_file_parser.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "ManageLambdaNetworkInterfaces"
+      Effect = "Allow"
+      Action = [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSubnets",
+        "ec2:DeleteNetworkInterface",
+        "ec2:AssignPrivateIpAddresses",
+        "ec2:UnassignPrivateIpAddresses",
+      ]
+      Resource = "*"
+    }]
+  })
 }
 
 output "iam_role_arn" {

--- a/lambda.tf
+++ b/lambda.tf
@@ -13,13 +13,22 @@ resource "aws_lambda_function" "state_file_parser" {
 
   image_uri = local.image_ref
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_config == null ? [] : [var.vpc_config]
+    content {
+      subnet_ids         = sort(tolist(vpc_config.value.subnet_ids))
+      security_group_ids = sort(tolist(vpc_config.value.security_group_ids))
+    }
+  }
+
   environment {
     variables = {
       ORGANIZATION_ID               = var.organization_id
       STATE_FILE_PATTERNS_JSON      = jsonencode(var.state_files)
       DEFAULT_BUCKET_DISCOVERY      = local.default_discovery ? "true" : "false"
       INFRACOST_STATE_BUCKET        = var.state_bucket
-      INFRACOST_STATE_BUCKET_REGION = "us-east-2"
+      INFRACOST_STATE_BUCKET_REGION = var.state_bucket_region
+      INFRACOST_STATE_BUCKET_PREFIX = var.state_bucket_prefix
       LOG_LEVEL                     = lower(var.log_level)
       EXPECTED_INTERVAL_SECONDS     = tostring(local.expected_interval_seconds)
       ALLOW_BUCKET_WILDCARDS        = "true"
@@ -27,11 +36,14 @@ resource "aws_lambda_function" "state_file_parser" {
     }
   }
 
-  depends_on = [aws_iam_role_policy_attachment.state_file_access_policy_attachement]
+  depends_on = [
+    aws_iam_role_policy_attachment.state_file_access_policy_attachement,
+    aws_iam_role_policy.vpc_access,
+  ]
 
   lifecycle {
     precondition {
-      condition     = contains(local.supported_image_regions, data.aws_region.current.id)
+      condition     = !local.managed_image || contains(local.supported_image_regions, data.aws_region.current.id)
       error_message = "The Infracost state-parser image is not replicated to this AWS region. Deploy in one of: ${join(", ", sort(tolist(local.supported_image_regions)))}."
     }
   }

--- a/locals.tf
+++ b/locals.tf
@@ -36,11 +36,16 @@ locals {
   )
   expected_interval_seconds = (local.period_days * 86400) + (local.period_hours * 3600) + (local.period_minutes * 60)
 
-  function_name  = "infracost-state-file-parser"
-  image_uri      = "237144093413.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/infracost/state-parser"
-  image_arn      = "arn:aws:ecr:${data.aws_region.current.id}:237144093413:repository/infracost/state-parser"
-  parser_version = "0.2.2"
-  image_ref      = "${local.image_uri}:${local.parser_version}"
+  function_name     = "infracost-state-file-parser"
+  image_uri         = "237144093413.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/infracost/state-parser"
+  image_arn         = "arn:aws:ecr:${data.aws_region.current.id}:237144093413:repository/infracost/state-parser"
+  parser_version    = "0.2.3"
+  managed_image_ref = "${local.image_uri}:${local.parser_version}"
+  managed_image     = var.parser_image_uri == null
+  image_ref         = local.managed_image ? local.managed_image_ref : var.parser_image_uri
+
+  state_bucket_key_prefix = var.state_bucket_prefix == "" ? "" : "${var.state_bucket_prefix}/"
+  state_report_key        = "${local.state_bucket_key_prefix}${var.organization_id}/aws_account_id=${data.aws_caller_identity.current.account_id}/terraform-state-resources.json"
 
   supported_image_regions = toset([
     "eu-central-1",

--- a/tests/customer_image_region.tftest.hcl
+++ b/tests/customer_image_region.tftest.hcl
@@ -1,0 +1,43 @@
+provider "aws" {
+  region                      = "eu-south-2"
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+}
+
+override_data {
+  target = data.aws_region.current
+  values = { id = "eu-south-2" }
+}
+
+override_data {
+  target = data.aws_caller_identity.current
+  values = { account_id = "123456789012" }
+}
+
+variables {
+  organization_id = "3f9fa4c5-e856-4312-8423-3c8380f3f05e"
+  state_files     = ["s3://customer-tfstate/env/prod/*.tfstate"]
+}
+
+run "managed_image_remains_region_limited" {
+  command = plan
+
+  expect_failures = [aws_lambda_function.state_file_parser]
+}
+
+run "customer_image_bypasses_only_managed_region_limit" {
+  command = plan
+
+  variables {
+    parser_image_uri = "123456789012.dkr.ecr.eu-south-2.amazonaws.com/state-parser:v0.2.3"
+  }
+
+  assert {
+    condition     = aws_lambda_function.state_file_parser.image_uri == var.parser_image_uri
+    error_message = "Customer images must be usable outside the managed-image replication regions."
+  }
+}

--- a/tests/module.tftest.hcl
+++ b/tests/module.tftest.hcl
@@ -43,11 +43,21 @@ run "minimal_default_contract" {
 
   assert {
     condition = (
-      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.2.2" &&
+      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.2.3" &&
       !contains(keys(aws_lambda_function.state_file_parser.environment[0].variables), "PARSER_AUTO_UPDATE") &&
       !strcontains(data.aws_iam_policy_document.state_file_access.json, "lambda:UpdateFunctionCode")
     )
     error_message = "The module must use its paired versioned parser release without self-update configuration or permissions."
+  }
+
+  assert {
+    condition = (
+      aws_lambda_function.state_file_parser.environment[0].variables.INFRACOST_STATE_BUCKET_REGION == "us-east-2" &&
+      aws_lambda_function.state_file_parser.environment[0].variables.INFRACOST_STATE_BUCKET_PREFIX == "" &&
+      length(aws_lambda_function.state_file_parser.vpc_config) == 0 &&
+      length(aws_iam_role_policy.vpc_access) == 0
+    )
+    error_message = "Default deployments must retain the managed destination and run without VPC attachment."
   }
 
   assert {
@@ -281,4 +291,149 @@ run "iam_interpolation_inputs_reject_wildcards" {
   }
 
   expect_failures = [var.organization_id, var.state_bucket]
+}
+
+run "customer_destination_is_exactly_scoped" {
+  command = plan
+
+  variables {
+    state_bucket        = "customer-reports"
+    state_bucket_region = "us-east-1"
+    state_bucket_prefix = "shared/reports"
+  }
+
+  assert {
+    condition = (
+      aws_lambda_function.state_file_parser.environment[0].variables.INFRACOST_STATE_BUCKET == "customer-reports" &&
+      aws_lambda_function.state_file_parser.environment[0].variables.INFRACOST_STATE_BUCKET_REGION == "us-east-1" &&
+      aws_lambda_function.state_file_parser.environment[0].variables.INFRACOST_STATE_BUCKET_PREFIX == "shared/reports"
+    )
+    error_message = "The parser must receive the configured customer destination."
+  }
+
+  assert {
+    condition = length([
+      for statement in jsondecode(data.aws_iam_policy_document.state_file_access.json).Statement : statement
+      if try(statement.Sid == "WriteSanitizedReports", false) &&
+      try(statement.Action == "s3:PutObject", false) &&
+      try(statement.Resource == "arn:aws:s3:::customer-reports/shared/reports/3f9fa4c5-e856-4312-8423-3c8380f3f05e/aws_account_id=123456789012/terraform-state-resources.json", false)
+    ]) == 1
+    error_message = "Customer destination IAM must allow only the exact prefixed report object."
+  }
+}
+
+run "invalid_destination_prefixes_are_rejected" {
+  command = plan
+
+  variables { state_bucket_prefix = "shared/*" }
+
+  expect_failures = [var.state_bucket_prefix]
+}
+
+run "vpc_configuration_adds_only_required_eni_access" {
+  command = plan
+
+  variables {
+    vpc_config = {
+      subnet_ids         = ["subnet-b", "subnet-a"]
+      security_group_ids = ["sg-b", "sg-a"]
+    }
+  }
+
+  assert {
+    condition = (
+      aws_lambda_function.state_file_parser.vpc_config[0].subnet_ids == toset(["subnet-a", "subnet-b"]) &&
+      aws_lambda_function.state_file_parser.vpc_config[0].security_group_ids == toset(["sg-a", "sg-b"])
+    )
+    error_message = "The Lambda must receive the supplied subnet and security-group IDs."
+  }
+
+  assert {
+    condition = (
+      length(aws_iam_role_policy.vpc_access) == 1 &&
+      toset(jsondecode(aws_iam_role_policy.vpc_access[0].policy).Statement[0].Action) == toset([
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSubnets",
+        "ec2:DeleteNetworkInterface",
+        "ec2:AssignPrivateIpAddresses",
+        "ec2:UnassignPrivateIpAddresses",
+      ]) &&
+      jsondecode(aws_iam_role_policy.vpc_access[0].policy).Statement[0].Resource == "*"
+    )
+    error_message = "VPC mode must grant exactly the six documented Lambda ENI actions on all resources."
+  }
+}
+
+run "empty_vpc_subnets_are_rejected" {
+  command = plan
+
+  variables {
+    vpc_config = {
+      subnet_ids         = []
+      security_group_ids = ["sg-a"]
+    }
+  }
+
+  expect_failures = [var.vpc_config]
+}
+
+run "empty_vpc_security_groups_are_rejected" {
+  command = plan
+
+  variables {
+    vpc_config = {
+      subnet_ids         = ["subnet-a"]
+      security_group_ids = []
+    }
+  }
+
+  expect_failures = [var.vpc_config]
+}
+
+run "customer_image_tag_disables_managed_ecr_access" {
+  command = plan
+
+  variables {
+    parser_image_uri = "123456789012.dkr.ecr.us-east-2.amazonaws.com/state-parser:v0.2.3"
+  }
+
+  assert {
+    condition     = aws_lambda_function.state_file_parser.image_uri == var.parser_image_uri
+    error_message = "A customer image tag must be passed to Lambda unchanged."
+  }
+
+  assert {
+    condition     = !strcontains(data.aws_iam_policy_document.state_file_access.json, "ecr:")
+    error_message = "Customer image mode must not add managed-image ECR permissions to the execution role."
+  }
+}
+
+run "customer_image_digest_is_accepted_with_vpc" {
+  command = plan
+
+  variables {
+    parser_image_uri = "123456789012.dkr.ecr.us-east-2.amazonaws.com/state-parser@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    vpc_config = {
+      subnet_ids         = ["subnet-a"]
+      security_group_ids = ["sg-a"]
+    }
+  }
+
+  assert {
+    condition = (
+      aws_lambda_function.state_file_parser.image_uri == var.parser_image_uri &&
+      length(aws_lambda_function.state_file_parser.vpc_config) == 1 &&
+      length(aws_iam_role_policy.vpc_access) == 1
+    )
+    error_message = "Customer digest and VPC modes must compose without enabling managed-image access."
+  }
+}
+
+run "blank_customer_image_is_rejected" {
+  command = plan
+
+  variables { parser_image_uri = " " }
+
+  expect_failures = [var.parser_image_uri]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -70,7 +70,7 @@ variable "log_level" {
 }
 
 variable "state_bucket" {
-  description = "Infracost-owned bucket that receives sanitized parser reports"
+  description = "S3 bucket that receives sanitized parser reports"
   type        = string
   default     = "infracost-incoming"
 
@@ -81,5 +81,67 @@ variable "state_bucket" {
       !can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$", var.state_bucket))
     )
     error_message = "state_bucket must be one exact, valid S3 bucket name; paths and wildcards are not accepted."
+  }
+}
+
+variable "state_bucket_region" {
+  description = "AWS region of the S3 bucket that receives sanitized parser reports"
+  type        = string
+  default     = "us-east-2"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}(-[a-z]+)+-[0-9]+$", var.state_bucket_region))
+    error_message = "state_bucket_region must be a valid AWS region name."
+  }
+}
+
+variable "state_bucket_prefix" {
+  description = "Optional S3 key prefix for sanitized parser reports"
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      var.state_bucket_prefix == "" ||
+      (
+        !startswith(var.state_bucket_prefix, "/") &&
+        !endswith(var.state_bucket_prefix, "/") &&
+        !strcontains(var.state_bucket_prefix, "//") &&
+        !strcontains(var.state_bucket_prefix, "\\") &&
+        !strcontains(var.state_bucket_prefix, "*") &&
+        !strcontains(var.state_bucket_prefix, "?") &&
+        !can(regex("[[:cntrl:]]", var.state_bucket_prefix)) &&
+        alltrue([for segment in split("/", var.state_bucket_prefix) : segment != "." && segment != ".."])
+      )
+    )
+    error_message = "state_bucket_prefix must be a clean S3 prefix without leading or trailing slashes, empty path segments, '.', '..', backslashes, or wildcard characters."
+  }
+}
+
+variable "vpc_config" {
+  description = "Optional VPC configuration in which to run the Lambda."
+  type = object({
+    subnet_ids         = set(string)
+    security_group_ids = set(string)
+  })
+  default = null
+
+  validation {
+    condition = var.vpc_config == null ? true : (
+      length(var.vpc_config.subnet_ids) > 0 &&
+      length(var.vpc_config.security_group_ids) > 0
+    )
+    error_message = "vpc_config must contain at least one subnet ID and one security group ID."
+  }
+}
+
+variable "parser_image_uri" {
+  description = "Optional customer-managed ECR image URI for the parser"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.parser_image_uri == null || try(trimspace(var.parser_image_uri) != "", false)
+    error_message = "parser_image_uri must not be blank."
   }
 }


### PR DESCRIPTION
## What changed

- allow sanitized parser reports to be written to a configurable S3 bucket, region, and prefix
- add optional Lambda VPC configuration using existing subnets and security groups
- grant the Lambda execution role the required ENI permissions only when VPC configuration is enabled
- allow customers to supply their own ECR parser image using either a tag or digest
- update the managed parser image to v0.2.3
- document cross-account destination policies, VPC responsibilities, and customer-managed image requirements
