### PR TITLE
chore: prepare module v0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 module "infracost_state_parser" {
-  source = "github.com/infracost/infracost-state-parser-module?ref=v0.2.3"
+  source = "github.com/infracost/infracost-state-parser-module?ref=v0.2.4"
 
   providers = {
     aws = aws
@@ -52,7 +52,7 @@ module "infracost_state_parser" {
   # }
 
   # Optional customer-managed parser image. Tags and digests are supported.
-  # parser_image_uri = "123456789012.dkr.ecr.us-west-2.amazonaws.com/infracost-state-parser:v0.2.3"
+  # parser_image_uri = "123456789012.dkr.ecr.us-west-2.amazonaws.com/infracost-state-parser:v0.2.4"
 }
 ```
 

--- a/locals.tf
+++ b/locals.tf
@@ -39,7 +39,7 @@ locals {
   function_name     = "infracost-state-file-parser"
   image_uri         = "237144093413.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/infracost/state-parser"
   image_arn         = "arn:aws:ecr:${data.aws_region.current.id}:237144093413:repository/infracost/state-parser"
-  parser_version    = "0.2.3"
+  parser_version    = "0.2.4"
   managed_image_ref = "${local.image_uri}:${local.parser_version}"
   managed_image     = var.parser_image_uri == null
   image_ref         = local.managed_image ? local.managed_image_ref : var.parser_image_uri

--- a/tests/customer_image_region.tftest.hcl
+++ b/tests/customer_image_region.tftest.hcl
@@ -33,7 +33,7 @@ run "customer_image_bypasses_only_managed_region_limit" {
   command = plan
 
   variables {
-    parser_image_uri = "123456789012.dkr.ecr.eu-south-2.amazonaws.com/state-parser:v0.2.3"
+    parser_image_uri = "123456789012.dkr.ecr.eu-south-2.amazonaws.com/state-parser:v0.2.4"
   }
 
   assert {

--- a/tests/module.tftest.hcl
+++ b/tests/module.tftest.hcl
@@ -43,7 +43,7 @@ run "minimal_default_contract" {
 
   assert {
     condition = (
-      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.2.3" &&
+      aws_lambda_function.state_file_parser.image_uri == "237144093413.dkr.ecr.us-east-2.amazonaws.com/infracost/state-parser:0.2.4" &&
       !contains(keys(aws_lambda_function.state_file_parser.environment[0].variables), "PARSER_AUTO_UPDATE") &&
       !strcontains(data.aws_iam_policy_document.state_file_access.json, "lambda:UpdateFunctionCode")
     )
@@ -395,7 +395,7 @@ run "customer_image_tag_disables_managed_ecr_access" {
   command = plan
 
   variables {
-    parser_image_uri = "123456789012.dkr.ecr.us-east-2.amazonaws.com/state-parser:v0.2.3"
+    parser_image_uri = "123456789012.dkr.ecr.us-east-2.amazonaws.com/state-parser:v0.2.4"
   }
 
   assert {


### PR DESCRIPTION
## Summary

- update the managed parser image to `0.2.4`
- update README examples and matching Terraform test fixtures to `v0.2.4`